### PR TITLE
Fix duplicate repository registration and add missing one

### DIFF
--- a/source-code/ECommerceBackend/src/ECommerceBackend.Infrastructure/InfrastructureConfiguration.cs
+++ b/source-code/ECommerceBackend/src/ECommerceBackend.Infrastructure/InfrastructureConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using ECommerceBackend.Application.Abstracts.Authentication;
 using ECommerceBackend.Application.Abstracts.Caching;
 using ECommerceBackend.Application.Abstracts.Clock;
@@ -139,7 +139,7 @@ public static class InfrastructureConfiguration
         services.AddScoped<IProductOptionValueRepository, ProductOptionValueRepository>();
         services.AddScoped<IProductMediaRepository, ProductMediaRepository>();
         services.AddScoped<IProductOptionTypeRepository, ProductOptionTypeRepository>();
-        services.AddScoped<IProductOptionValueRepository, ProductOptionValueRepository>();
+        services.AddScoped<IProductVariantOptionValueRepository, ProductVariantOptionValueRepository>();
 
         services.TryAddScoped<IUnitOfWork>(provider => provider.GetRequiredService<ApplicationDbContext>());
 


### PR DESCRIPTION
Correct DI registration for `IProductVariantOptionValueRepository`.

The previous configuration had a duplicate registration for `IProductOptionValueRepository` and was missing the registration for `IProductVariantOptionValueRepository`, leading to runtime errors when the latter was requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-dcfcb261-fc47-434c-9dc5-1e026e82b4a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dcfcb261-fc47-434c-9dc5-1e026e82b4a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

